### PR TITLE
Adding rds to s3 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Notes
 The script iterates over 50 plant IDs and fetches data for each plant.
 Duplicate and None values are appropriately handled.
 
-## s3_data_management
+
+
+## s3_data_management/
 Contains files for management of data in s3 bucket; to be run daily *after* midnight, to combine the csv from the day before into the monthly csv. Assumes an s3 file structure as follows:
 - `{year}`
     - `{month}`
@@ -107,3 +109,9 @@ At the end of each month, the month folder will contain only two csv files, `wat
 ## rds_to_s3.py
 Contains code to retrieve watering/recording data older than 24hrs from the database, append it to
 the relevant files in s3 (automatically creates if none exist), and delete from the db.
+
+Entire functionality is run by calling function `update_rds_and_s3()`, with no arguments, which is called automatically when the function is run from the commandline.
+
+### Requirements to run
+- Written to use a .env file with AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, BUCKET_NAME, DB_HOST, BB_PORT, DB_NAME, DB_SCHEMA, DB_USER, DB_PASSWORD
+- Library requirements in file `requirements.txt` in parent directory

--- a/README.md
+++ b/README.md
@@ -99,4 +99,5 @@ And, after the script is run, would look like:
 At the end of each month, the month folder will contain only two csv files, `watering.csv` and `recording.csv`.
 
 ### Requirements to run
-Written to use a .env file with AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, BUCKET_NAME.
+- Written to use a .env file with AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, BUCKET_NAME.
+- Library requirements in file `requirements.txt`

--- a/README.md
+++ b/README.md
@@ -113,5 +113,6 @@ the relevant files in s3 (automatically creates if none exist), and delete from 
 Entire functionality is run by calling function `update_rds_and_s3()`, with no arguments, which is called automatically when the function is run from the commandline.
 
 ### Requirements to run
+- Assumes same s3 file structure as detailed in notes for `s3_data_management/`
 - Written to use a .env file with AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, BUCKET_NAME, DB_HOST, BB_PORT, DB_NAME, DB_SCHEMA, DB_USER, DB_PASSWORD
 - Library requirements in file `requirements.txt` in parent directory

--- a/README.md
+++ b/README.md
@@ -101,3 +101,9 @@ At the end of each month, the month folder will contain only two csv files, `wat
 ### Requirements to run
 - Written to use a .env file with AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, BUCKET_NAME.
 - Library requirements in file `requirements.txt`
+
+
+
+## rds_to_s3.py
+Contains code to retrieve watering/recording data older than 24hrs from the database, append it to
+the relevant files in s3 (automatically creates if none exist), and delete from the db.


### PR DESCRIPTION
Documentation added to `README.md` (in root directory) for the file rds_to_s3.py; minor change made to part of the readme for `s3_data_management/` as well