### PR TITLE
Update pipeline to fix error in s3 file names

### DIFF
--- a/pipeline/rds_to_s3.py
+++ b/pipeline/rds_to_s3.py
@@ -15,7 +15,6 @@ from sqlalchemy.engine.base import Connection
 
 load_dotenv()
 LITERAL_DAY_AGO = (datetime.now() - timedelta(hours = 24))
-TODAY = datetime.today()
 
 
 def get_database_engine():
@@ -47,7 +46,7 @@ def get_old_records(table_name: str, db_engine: db.Engine, connection: Connectio
         raise e
 
 
-def get_day_bucket_keys(s3_client: client, folder_path: str, day: int = TODAY.day,
+def get_day_bucket_keys(s3_client: client, folder_path: str, day: int = LITERAL_DAY_AGO.day,
                     bucket_name: str = environ['BUCKET_NAME']) -> list:
     """
     Returns list of keys within a given s3 bucket ending in '_{day}.csv, with a prefix matching
@@ -60,7 +59,7 @@ def get_day_bucket_keys(s3_client: client, folder_path: str, day: int = TODAY.da
 
 
 def get_current_csv_data(data_type: str, s3_client: client, bucket_name:
-                         str = environ['BUCKET_NAME'], date: str = TODAY) -> pd.DataFrame:
+                         str = environ['BUCKET_NAME'], date: str = LITERAL_DAY_AGO) -> pd.DataFrame:
     """
     Downloads relevant files of specified data_type (watering/recording) from S3 to local, and
     then returns it as a pandas dataframe.
@@ -82,7 +81,7 @@ def get_current_csv_data(data_type: str, s3_client: client, bucket_name:
 
 
 def upload_to_s3(data_type: str, df: pd.DataFrame, s3_client,
-                 bucket_name: str = environ['BUCKET_NAME'], date: str = TODAY):
+                 bucket_name: str = environ['BUCKET_NAME'], date: str = LITERAL_DAY_AGO):
     """Uploads pandas dataframe of data_type to appropriate csv in s3 bucket."""
     s3_client.put_object(Body = df.to_csv(index=False), Bucket = bucket_name,
                          Key = f'{date.year}/{date.month}/{data_type}_{date.day}.csv')

--- a/pipeline/rds_to_s3.py
+++ b/pipeline/rds_to_s3.py
@@ -49,7 +49,7 @@ def get_old_records(table_name: str, db_engine: db.Engine, connection: Connectio
 def get_day_bucket_keys(s3_client: client, folder_path: str, day: int = LITERAL_DAY_AGO.day,
                     bucket_name: str = environ['BUCKET_NAME']) -> list:
     """
-    Returns list of keys within a given s3 bucket ending in '_{day}.csv, with a prefix matching
+    Returns list of keys within a given s3 bucket ending in '_{yesterday}.csv, with a prefix matching
     the given folder_path.
     """
     objects = s3_client.list_objects(Bucket=bucket_name, Prefix=folder_path).get('Contents')
@@ -108,7 +108,7 @@ def update_rds_and_s3():
     """
     Gets any records from watering and recording tables in df older than 24hours, combines with
     the csv files in s3 bucket for current day (if any exist), and saves the result as csvs in the
-    bucket with a name ending in _{day}.csv.
+    bucket with a name ending in _{yesterday}.csv.
     """
     db_engine = get_database_engine()
     db_connection = db_engine.connect()


### PR DESCRIPTION
Data was being uploaded to s3 file named after current date, but the data being uploaded to the s3 is always 24hrs old, and this would cause it to end up in the wrong month/year folder when the pipeline would run on certain dates.

<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;D9H61twy">Preemptive bug: s3 file labelling needs to change today to yesterday, and yesterday to the day before in both pipeline and s3_data_management</a></blockquote><script src="https://p.trellocdn.com/embed.min.js"></script>