### PR TITLE
Adding unique contraint to watering table

### DIFF
--- a/db_setup/schema.sql
+++ b/db_setup/schema.sql
@@ -36,8 +36,12 @@ CREATE TABLE s_beta.watering(
 );
 GO
 
-ALTER TABLE
-    s_beta.watering ADD CONSTRAINT "watering_id_primary" PRIMARY KEY("id");
+ALTER TABLE s_beta.watering
+    ADD CONSTRAINT "plant_id_primary" PRIMARY KEY("id");
+GO
+
+ALTER TABLE s_beta.watering
+    ADD CONSTRAINT "unique_watering_events" UNIQUE ("plant_id", "datetime");
 GO
 
 

--- a/db_setup/schema.sql
+++ b/db_setup/schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE s_beta.watering(
 GO
 
 ALTER TABLE s_beta.watering
-    ADD CONSTRAINT "plant_id_primary" PRIMARY KEY("id");
+    ADD CONSTRAINT "watering_id_primary" PRIMARY KEY("id");
 GO
 
 ALTER TABLE s_beta.watering

--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -32,12 +32,13 @@ def upload_recordings(data, conn: Connection, table: db.Table) -> None:
 def upload_waterings(data, conn: Connection, table: db.Table) -> None:
     """Uploads watering data to the database."""
     data_dict = data.to_dict(orient='records')
-    try:
-        conn.execute(table.insert(), data_dict)
-        conn.commit()
-    except Exception as e:
-        conn.rollback()
-        raise e
+    for watering in data_dict:
+        try:
+            query = db.insert(table).values(plant_id = watering['plant_id'], datetime = watering['datetime'])
+            conn.execute(query)
+            conn.commit()
+        except Exception as e:
+            conn.rollback()
 
 
 def load(recordings, waterings) -> None:


### PR DESCRIPTION
Schema changed to add unique constraint; also had to change `load.py` to insert rows to watering table one by one in case of unique violations – searched for ages, but it just doesn't look like sqlalchemy has support for multiinsert conflict handling for pymssql (and so FreeTDS and so t-sql). Hopefully won't slow the pipeline too much.